### PR TITLE
Fix "can't resolve fs"

### DIFF
--- a/core/src/lib/setup/getSigner.ts
+++ b/core/src/lib/setup/getSigner.ts
@@ -1,7 +1,6 @@
 import { IWalletSelectorProps, IServerSideProps, IQueryResponseKindCustom, ISigner } from "../types";
-import { Account, KeyPair, connect } from "near-api-js";
+import { Account, KeyPair, keyStores, connect } from "near-api-js";
 import { JsonRpcProvider } from "near-api-js/lib/providers";
-import { InMemoryKeyStore } from "near-api-js/lib/key_stores";
 
 /**
 	* Ideal for server side usage
@@ -13,7 +12,7 @@ export const getSignerFromPrivateKey = async ({ network, accountId, privateKey }
 
 	// Create signer using keypair and accounts from near-api-js for server side usage
 	const keyPair = KeyPair.fromString(privateKey)
-	const keyStore = new InMemoryKeyStore()
+	const keyStore = new keyStores.InMemoryKeyStore()
 	await keyStore.setKey(network, accountId, keyPair)
 
 	const nearConnection = await connect({


### PR DESCRIPTION
This fixes Next.js app build error:

```
│ Failed to compile.
│ ../node_modules/.pnpm/@near-js+keystores-node@0.0.12/node_modules/@near-js/keystores-node/lib/unencrypted_file_system_ke…
│ Module not found: Can't resolve 'fs'
│ https://nextjs.org/docs/messages/module-not-found
│ Import trace for requested module:
│ ../node_modules/.pnpm/@near-js+keystores-node@0.0.12/node_modules/@near-js/keystores-node/lib/index.js
│ ../node_modules/.pnpm/near-api-js@4.0.3/node_modules/near-api-js/lib/key_stores/unencrypted_file_system_keystore.js
│ ../node_modules/.pnpm/near-api-js@4.0.3/node_modules/near-api-js/lib/key_stores/index.js
│ ../core/dist/index.mjs
│ ./src/pages/index.tsx
│ > Build failed because of webpack errors
```

`import { InMemoryKeyStore } from "near-api-js/lib/key_stores";` tells the bundler to include a node specific package.

getSigner has two methods, `getSignerFromPrivateKey`, which is meant for node environments, and `getSignerFromWalletSelector` which is meant for browser. These being in the same file means they both get included no matter what. With the specific inMemoryKeyStore import and no code splitting, this means the node-specific class, which uses fs, will break our browser environment.

There are a two solutions to this:

- [ ] Split getSignerFromPrivateKey and getSignerFromWalletSelector into their own separate files, so only the valid method is being imported and unused function w/ imports can be tree shaken out.
- [x] Remove the explicit import and import keyStores, which I believe handles the code splitting for us? Although I wouldn't be surprised if it means a bigger bundle -- not sure. (this was easiest and is current PR)

The same could be done for JsonRpcProvider if that ever gives a problem, import { providers } from "near-api-js" and do `new providers.JsonRpcProvider`
